### PR TITLE
Updates for API v47.0

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -3,4 +3,13 @@
 #
 
 package.xml
+
+# Profiles
 **profiles
+
+# LWC configuration files
+**/jsconfig.json
+**/.eslintrc.json
+
+# LWC Jest
+**/__tests__/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,31 @@
-.sfdx
-.vscode
-.idea
-IlluminatedCloud
+# This file is used for Git repositories to specify intentionally untracked files that Git should ignore.
+# If you are not using git, you can delete this file. For more information see: https://git-scm.com/docs/gitignore
+# For useful gitignore templates see: https://github.com/github/gitignore
+
+# Salesforce cache
+.sfdx/
+
+# Visual Studio Code files
+.vscode/
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Dependency directories
+node_modules/
+
+# Eslint cache
+.eslintcache
+
+# MacOS system files
+.DS_Store
+
+# Windows system files
+Thumbs.db
+ehthumbs.db
+[Dd]esktop.ini
+$RECYCLE.BIN/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+# List files or directories below to ignore them when running prettier
+# More information: https://prettier.io/docs/en/ignore.html
+#
+
+.sfdx

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,13 @@
+{
+  "trailingComma": "none",
+  "overrides": [
+    {
+      "files": "**/lwc/**/*.html",
+      "options": { "parser": "lwc" }
+    },
+    {
+      "files": "*.{cmp,page,component}",
+      "options": { "parser": "html" }
+    }
+  ]
+}

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,9 +1,13 @@
 {
-    "orgName": "GIFter",
-    "edition": "Developer",
-    "settings" : {
-        "orgPreferenceSettings" : {
-          "s1EncryptedStoragePref2" : false
-        }
+  "orgName": "GIFter",
+  "edition": "Developer",
+  "features": [],
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "mobileSettings": {
+      "enableS1EncryptedStoragePref2": false
     }
+  }
 }

--- a/force-app/main/default/aura/SearchGIPHY/SearchGIPHY.cmp
+++ b/force-app/main/default/aura/SearchGIPHY/SearchGIPHY.cmp
@@ -1,5 +1,5 @@
-<aura:component 
-    implements="force:appHostable,flexipage:availableForAllPageTypes" 
+<aura:component
+    implements="force:appHostable,flexipage:availableForAllPageTypes"
     controller="ChatterHelper">
 
   <aura:attribute name="searchTerms" type="String" />
@@ -12,8 +12,8 @@
 
   <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
 
-  <ltng:require scripts="{!join(',', 
-      $Resource.jquery331, 
+  <ltng:require scripts="{!join(',',
+      $Resource.jquery331,
       $Resource.GIPHY)}" afterScriptsLoaded="{!c.afterScriptsLoaded}" />
 
   <aura:if isTrue="{!v.showModal==true}">
@@ -78,7 +78,5 @@
 
     </lightning:layout>
   </lightning:card>
-
-
 
 </aura:component>

--- a/force-app/main/default/aura/SearchGIPHY/SearchGIPHY.cmp-meta.xml
+++ b/force-app/main/default/aura/SearchGIPHY/SearchGIPHY.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="urn:metadata.tooling.soap.sforce.com" fqn="SearchGIPHY">
-    <apiVersion>44.0</apiVersion>
+    <apiVersion>47.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/aura/SearchGIPHY/SearchGIPHY.css
+++ b/force-app/main/default/aura/SearchGIPHY/SearchGIPHY.css
@@ -15,7 +15,6 @@
   margin-left: 8px;
 }
 
-
 .THIS .preview-image {
   text-align: center;
 }

--- a/force-app/main/default/classes/ChatterHelper.cls-meta.xml
+++ b/force-app/main/default/classes/ChatterHelper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ChatterHelper">
-    <apiVersion>44.0</apiVersion>
+    <apiVersion>47.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/tabs/GIFter.tab-meta.xml
+++ b/force-app/main/default/tabs/GIFter.tab-meta.xml
@@ -3,6 +3,5 @@
     <description>Created by Lightning App Builder</description>
     <flexiPage>GIFter</flexiPage>
     <label>Search</label>
-    <mobileReady>true</mobileReady>
     <motif>Custom67: Gears</motif>
 </CustomTab>


### PR DESCRIPTION
* Updates metadata API version to 47.0
* Updates `config/project-scratch-def.json` to current org settings configuration.
* Updates `.gitignore` and `.forceignore` per how CLI creates new projects.
* Adds `.prettierrc` and `.prettierignore` per how CLI creates new projects.
* Removes [deprecated](https://releasenotes.docs.salesforce.com/en-us/summer19/release-notes/rn_api_meta.htm) `<mobileReady>` property from CustomTab metadata.
* Removes extra newlines and trailing whitespace.