### PR TITLE
fixed outdated property; updated to API v49

### DIFF
--- a/force-app/main/default/aura/SearchGIPHY/SearchGIPHY.cmp-meta.xml
+++ b/force-app/main/default/aura/SearchGIPHY/SearchGIPHY.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="urn:metadata.tooling.soap.sforce.com" fqn="SearchGIPHY">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>49.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/force-app/main/default/classes/ChatterHelper.cls-meta.xml
+++ b/force-app/main/default/classes/ChatterHelper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ChatterHelper">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>49.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/flexipages/GIFter.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/GIFter.flexipage-meta.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FlexiPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <flexiPageRegions>
-        <componentInstances>
-            <componentName>SearchGIPHY</componentName>
-        </componentInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentName>SearchGIPHY</componentName>
+            </componentInstance>
+        </itemInstances>
         <name>main</name>
         <type>Region</type>
     </flexiPageRegions>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -7,5 +7,5 @@
     ],
     "namespace": "",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "47.0"
+    "sourceApiVersion": "49.0"
 }


### PR DESCRIPTION
I tried the unlocked package trailhead [module](https://trailhead.salesforce.com/en/content/learn/projects/quick-start-unlocked-packages/get-ready-to-create-your-first-unlocked-package) and ran into [this issue](https://salesforce.stackexchange.com/questions/305221/metadata-deploy-and-push-fails-on-flexipage-componentinstances-in-api-49-summer), can we update to make it work for v49.0?
